### PR TITLE
Allow building with GHC 9.4

### DIFF
--- a/bv-sized-float.cabal
+++ b/bv-sized-float.cabal
@@ -16,7 +16,7 @@ extra-source-files:  README.md
 library
   exposed-modules:     Data.BitVector.Sized.Float
   build-depends:       base >= 4.9 && < 5
-                     , bv-sized >= 1.0.2 && < 1.0.5
+                     , bv-sized >= 1.0.2 && < 1.0.6
                      , containers >= 0.5.10 && < 0.7
                      , mtl >= 2 && < 3
                      , parameterized-utils


### PR DESCRIPTION
This patch:

* Bumps the upper version bounds on `bv-sized` to allow building with a version that supports GHC 9.4.
* Bumps the `parameterized-utils` submodule to bring in the changes from GaloisInc/parameterized-utils#146, which is needed to make it build with GHC 9.4.