### PR TITLE
Remove unused `parameterized-utils` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "submodules/parameterized-utils"]
-	path = submodules/parameterized-utils
-	url = https://github.com/GaloisInc/parameterized-utils.git
 [submodule "submodules/softfloat-hs"]
 	path = submodules/softfloat-hs
 	url = https://github.com/GaloisInc/softfloat-hs.git


### PR DESCRIPTION
Although `bv-sized-float` declared `parameterized-utils` as a submodule, it wasn't actually depending on it in the `cabal.project` file. Let's just remove this submodule to avoid confusion.